### PR TITLE
Update to xmr-stak 2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM alpine:edge AS build
 #FROM alpine:edge
 
-ENV XMR_STAK_VERSION v2.2.0
+ENV XMR_STAK_VERSION 2.3.0
 
 COPY app /app
 
@@ -25,7 +25,7 @@ RUN git clone https://github.com/fireice-uk/xmr-stak.git \
     && git checkout tags/${XMR_STAK_VERSION} -b build  \
     && sed -i 's/constexpr double fDevDonationLevel.*/constexpr double fDevDonationLevel = 0.0;/' xmrstak/donate-level.hpp \
     \
-    && cmake . -DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF -DHWLOC_ENABLE=OFF -DXMR-STAK_COMPILE=generic \
+    && cmake . -DCUDA_ENABLE=OFF -DOpenCL_ENABLE=OFF -DHWLOC_ENABLE=ON -DXMR-STAK_COMPILE=generic \
     && make -j$(nproc) \
     \
     && cp -t /app bin/xmr-stak \

--- a/app/docker-entrypoint.sh
+++ b/app/docker-entrypoint.sh
@@ -8,9 +8,10 @@ fi
 
 envtpl /app/xmr-stak-cpu.config.tpl -o /app/config.txt --allow-missing --keep-template
 envtpl /app/xmr-stak-cpu.cpu.tpl -o /app/cpu.txt --allow-missing --keep-template
+envtpl /app/xmr-stak-cpu.pools.tpl -o /app/pools.txt --allow-missing --keep-template
 
 if [ "$1" = 'xmr-stak-cpu' ]; then
-    exec /app/xmr-stak --cpu /app/cpu.txt -c /app/config.txt
+    exec /app/xmr-stak --cpu /app/cpu.txt -c /app/config.txt -C /app/pools.txt
 fi
 
 exec "$@"

--- a/app/xmr-stak-cpu.config.tpl
+++ b/app/xmr-stak-cpu.config.tpl
@@ -1,16 +1,4 @@
 
-"pool_list" :
-[
-	{"pool_address" : "{{ POOL_ADDRESS | default("pool.supportxmr.com:5555") }}", "wallet_address" : "{{ WALLET_ADDRESS | default("") }}", "pool_password" : "{{ POOL_PASSWORD | default("") }}", "use_nicehash" : {{ USE_NICEHASH | default("false") }}, "use_tls" : {{ USE_TLS | default("false") }}, "tls_fingerprint" : "{{ TLS_FINGERPRINT | default("") }}", "pool_weight" : 1 },
-],
-
-/*
- * currency to mine
- * allowed values: 'monero' or 'aeon'
- */
-"currency" : "{{ CURRENCY | default("monero") }}",
-
-
 /*
  * LARGE PAGE SUPPORT
  * Large pages need a properly set up OS. It can be difficult if you are not used to systems administation,

--- a/app/xmr-stak-cpu.pools.tpl
+++ b/app/xmr-stak-cpu.pools.tpl
@@ -1,0 +1,6 @@
+"pool_list" :
+[
+	{"pool_address" : "{{ POOL_ADDRESS | default("pool.supportxmr.com:5555") }}", "wallet_address" : "{{ WALLET_ADDRESS | default("") }}", "rig_id" : "{{ RIG_ID | default("") }}", "pool_password" : "{{ POOL_PASSWORD | default("") }}", "use_nicehash" : {{ USE_NICEHASH | default("false") }}, "use_tls" : {{ USE_TLS | default("false") }}, "tls_fingerprint" : "{{ TLS_FINGERPRINT | default("") }}", "pool_weight" : 1 },
+],
+
+"currency" : "{{ CURRENCY | default("monero7") }}",


### PR DESCRIPTION
I had to set `HWLOC_ENABLE=ON` because of a [compile error](https://github.com/fireice-uk/xmr-stak/issues/1210)

I also set the default currency to `monero7` in preparation for the upcoming POW changes.